### PR TITLE
return nested objects in the api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 develop-eggs/
 dist/
 downloads/
+results/
 eggs/
 .eggs/
 lib/

--- a/src/altpoet/serializers.py
+++ b/src/altpoet/serializers.py
@@ -2,7 +2,7 @@ from django.contrib.auth.models import User
 
 from rest_framework import serializers
 
-from altpoet.models import Document, Img, Alt
+from altpoet.models import Document, Img, Alt, Agent
 
 
 # Serializers define the API representation.
@@ -11,25 +11,30 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
         model = User
         fields = ['url', 'username', 'email', 'is_staff']
 
+
+class AltSerializer(serializers.ModelSerializer):
+    source = serializers.SlugRelatedField(
+        many=False, read_only=True, slug_field='name')
+    class Meta:
+        model = Alt
+        fields = ['id', 'text', 'source', 'created']
+
+
+class ImgSerializer(serializers.ModelSerializer):
+    image = serializers.SlugRelatedField(many=False, read_only=True, slug_field='url')
+    alt = serializers.PrimaryKeyRelatedField(
+        many=False, read_only=False, allow_null=True, queryset=Alt.objects.all())
+    alts = AltSerializer(many=True, read_only=True)
+    class Meta:
+        model = Img
+        fields = ['id', 'image', 'img_id', 'img_type', 'is_figure', 'alt', 'alts']
+
+
 class DocumentSerializer(serializers.ModelSerializer):
     project = serializers.SlugRelatedField(many=False, read_only=True, slug_field='name')
-    imgs = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='img-detail')
+    imgs = ImgSerializer(many=True, read_only=True)
     class Meta:
         model = Document
         fields = ['project', 'id', 'item', 'base', 'imgs']
         
 
-class ImgSerializer(serializers.ModelSerializer):
-    image = serializers.SlugRelatedField(many=False, read_only=True, slug_field='url')
-    alt = serializers.HyperlinkedRelatedField(many=False, read_only=True, view_name='alt-detail')
-    alts = serializers.HyperlinkedRelatedField(many=True, read_only=True, view_name='alt-detail')
-    class Meta:
-        model = Img
-        fields = ['image', 'img_id', 'img_type', 'is_figure', 'alt', 'alts']
-
-
-class AltSerializer(serializers.ModelSerializer):
-    source = serializers.SlugRelatedField(many=False, read_only=True, slug_field='name')
-    class Meta:
-        model = Alt
-        fields = ['text', 'source', 'created']


### PR DESCRIPTION
turned out to be reasonably easy.
document results include nested Img objects, which include nested Alt objects, so one call can be used to render an editing UI