### PR TITLE
Fix typos in homepage and alt-text guide templates

### DIFF
--- a/src/altpoet/templates/alttext.html
+++ b/src/altpoet/templates/alttext.html
@@ -23,7 +23,7 @@ Creating Good Alt Text
 <dd>Blind people are as smart as you are. If a picture shows a smiling boy in ragged clothes, don't describe him as poor but happy.
 </dd>
 <dt>Images are there for a reason.</dt>
-<dd>Images typically are there to comunicate something. Alt text should try to communicate the same thing. For example, an image of a scrap of ancient text is not there to communicate the words on the scrap, it's there to convey an impression of the scrap's fragmentary nature. Alt text should focus on that. The caption in the book might tell you what museum it's in, without conveying visual information.
+<dd>Images typically are there to communicate something. Alt text should try to communicate the same thing. For example, an image of a scrap of ancient text is not there to communicate the words on the scrap, it's there to convey an impression of the scrap's fragmentary nature. Alt text should focus on that. The caption in the book might tell you what museum it's in, without conveying visual information.
 </dd>
 <dt>Often, null text is best.</dt>
 <dd>Books often use images as decorations, page breaks, spacers, and the like. These should not have alt text, as it the alt text will just be annoying interruptions.  In Altpoet, use the "decorative image" button to indicate that they are better left undescribed. Similarly if an image is part of a figure and the figure label already describes the image, it's usually better not to repeat the description.
@@ -35,7 +35,7 @@ Creating Good Alt Text
 <dd>Screen readers take pauses for things commas and periods. Use the same grammar and spelling style guides you use for visually presented text.
 </dd>
 <dt>Spell check.</dt>
-<dd>Because it is “invisible” it’s easy to make typos in your alt text writing. AltPoet makkes it easy to reviewed and proofread, the work of others (including AIs!).
+<dd>Because it is “invisible” it’s easy to make typos in your alt text writing. AltPoet makes it easy to review and proofread the work of others (including AIs!).
 </dd>
 <dt>Don’t game the system.</dt>
 <dd>Since alt text will increase SEO performance, a lot of the training data used for AIs has alt text descriptions with keywords. Alt text is about fairness and inclusion first, last, and always.

--- a/src/altpoet/templates/index.html
+++ b/src/altpoet/templates/index.html
@@ -9,7 +9,7 @@
 Welcome to AltPoet!
 </h1>
 <p style='box-sizing: content-box'>
-This website enables the editing and creation of alt-text descriptions to make Project Gutenberg ebooks accesible to the blind and vision-impaired. 
+This website enables the editing and creation of alt-text descriptions to make Project Gutenberg ebooks accessible to the blind and vision-impaired. 
 </p>
 
 {% if form.errors and not form.non_field_errors %}


### PR DESCRIPTION
- index.html line 12: 'accesible' -> 'accessible'
- alttext.html line 26: 'comunicate' -> 'communicate'
- alttext.html line 38: 'AltPoet makkes it easy to reviewed and proofread, the work of others' -> 'AltPoet makes it easy to review and proofread the work of others'

The third edit corrects three things in a single sentence: the misspelled 'makkes', the ungrammatical 'to reviewed', and a misplaced comma that broke the verb-object relationship.