### PR TITLE
Copy edit alttext.html: grammar, punctuation, capitalization

### DIFF
--- a/src/altpoet/templates/alttext.html
+++ b/src/altpoet/templates/alttext.html
@@ -26,13 +26,13 @@ Creating Good Alt Text
 <dd>Images typically are there to comunicate something. Alt text should try to communicate the same thing. For example, an image of a scrap of ancient text is not there to communicate the words on the scrap, it's there to convey an impression of the scrap's fragmentary nature. Alt text should focus on that. The caption in the book might tell you what museum it's in, without conveying visual information.
 </dd>
 <dt>Often, null text is best.</dt>
-<dd>Books often use images as decorations, page breaks, spacers, and the like. These should not have alt text, as it the alt text will just be annoying interruptions.  In Altpoet, use the "decorative image" button to indicate that they are better left undescribed. Similarly if an image is part of a figure and the figure label already describes the image, it's usually better not to repeat the description.
+<dd>Books often use images as decorations, page breaks, spacers, and the like. These should not have alt text, as the alt text will just be an annoying interruption. In AltPoet, use the "decorative image" button to indicate that they are better left undescribed. Similarly if an image is part of a figure and the figure label already describes the image, it's usually better not to repeat the description.
 </dd>
 <dt>Front load the important stuff.</dt>
 <dd>Some screen readers naturally pause after 140 characters with spaces and require a user action to read more. Consider that a definition of “front loading” and put the most pertinent information in that 140-character container.
 </dd>
 <dt>Use punctuation.</dt>
-<dd>Screen readers take pauses for things commas and periods. Use the same grammar and spelling style guides you use for visually presented text.
+<dd>Screen readers take pauses for things like commas and periods. Use the same grammar and spelling style guides you use for visually presented text.
 </dd>
 <dt>Spell check.</dt>
 <dd>Because it is “invisible” it’s easy to make typos in your alt text writing. AltPoet makkes it easy to reviewed and proofread, the work of others (including AIs!).
@@ -44,7 +44,7 @@ Creating Good Alt Text
 <dd>Screen readers naturally announce the role of the &lt;img&gt; element in HTML and &lt;figure&gt; tag in PDF by stating “Graphic” or “Image”. Instead, just describe the image as though the user already understands fully that it’s an image. This holds true for all image formats except animated GIFs.
 </dd>
 <dt>Other types of image</dt>
-<dd>When describing an animated GIF, start (prepend) the description with the term “Animated GIF” or “Animation”. The screen reader will only announce role of “image” so this extra description is useful for non-sighted users. Similarly, the terms "map", "drawing", "graph", and "formula" can be useful, provided that there's more in the description!.
+<dd>When describing an animated GIF, start (prepend) the description with the term “Animated GIF” or “Animation”. The screen reader will only announce the role of “image” so this extra description is useful for non-sighted users. Similarly, the terms "map", "drawing", "graph", and "formula" can be useful, provided that there's more in the description!
 </dd>
 <dt>Don’t over engineer it</dt>
 <dd>Some abbreviations will not read “correctly” to your ear when you listen to them with a screen reader. Your first thought may be to engineer it phonetically to read correctly. The term ADA for example can be read aloud like Ada Lovelace instead of the abbreviation for the Americans with Disabilities Act which phonetically is pronounced like Eh Dee Eh. Whereas this approach works well for screen reader users it will not work for Braille display users.


### PR DESCRIPTION
Copy edits to docs/alttext.html:

- Line 29: fix garbled phrasing ("as it the alt text will just be annoying interruptions" → "as the alt text will just be an annoying interruption") and capitalize "AltPoet" to match project branding.
- Line 35: insert missing word ("pauses for things commas" → "pauses for things like commas").
- Line 47: insert missing article ("announce role of" → "announce the role of") and remove stray period after exclamation point ("description!." → "description!").

No functional or structural changes — text/grammar only.