### PR TITLE
Clean up index.html: remove duplicate load tag and redundant error sentence

### DIFF
--- a/src/altpoet/templates/index.html
+++ b/src/altpoet/templates/index.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load static %}
-{% load static %}
 
 {% block title %}Free Ebook Foundation's AltPoet{% endblock %}
 
@@ -14,7 +13,7 @@ This website enables the editing and creation of alt-text descriptions to make P
 
 {% if form.errors and not form.non_field_errors %}
 <p class="errornote">
-Please correct the error below. Please correct the errors below.
+Please correct the errors below.
 </p>
 {% endif %}
 


### PR DESCRIPTION
Cleanup edits to src/altpoet/templates/index.html:

- Removed duplicate `{% load static %}` template tag (line 3 was an exact repeat of line 2).
- Collapsed redundant error sentence on line 17 ("Please correct the error below. Please correct the errors below." → "Please correct the errors below.").

No functional or structural changes.
