### PR TITLE
Update README clone URL to gutenbergtools org

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ https://pipenv.pypa.io/en/latest/installation.html
 
 ### altpoet
 
-`git clone https://github.com/EbookFoundation/altpoet.git`
+`git clone https://github.com/gutenbergtools/altpoet.git`
 
 create a python env in the new altpoet directory:
 `pipenv shell`


### PR DESCRIPTION
Updates the `git clone` example on line 34 of README.md from the legacy `EbookFoundation/altpoet` URL to the canonical `gutenbergtools/altpoet` URL.

GitHub's transfer redirect currently makes the old URL still functional, but:
- Documentation should reference the canonical repository directly.
- The redirect can be invalidated if a new repo is ever created at the old name.
- All other project docs and links already use `gutenbergtools/altpoet`.

No functional changes.