### PR TITLE
Minor markdown cleanup to make the README readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ https://www.postgresql.org/download/
 Alt-Poet development is using version 14.
 
 create a database called `altpoet`
-```CREATE DATABASE altpoet
+```sql
+CREATE DATABASE altpoet
     WITH
     OWNER = postgres
     ENCODING = 'UTF8'
@@ -20,46 +21,54 @@ create a database called `altpoet`
     TABLESPACE = pg_default
     CONNECTION LIMIT = -1
     IS_TEMPLATE = False;
-    ```
+```
 
 ### Python
 
-Alt-Poet development is using version 3.9
+Alt-Poet development is using python version 3.9.
 PyEnv can be used to manage multiple python versions on one machine.
 You'll want to install Pip and Pipenv (or a flavor of environment management that accepts pipfiles)
 https://pipenv.pypa.io/en/latest/installation.html
 
 ### altpoet
 
-`git clone https://github.com/gutenbergtools/altpoet.git`
+1. Clone the repo
 
-create a python env in the new altpoet directory:
-`pipenv shell`
+   `git clone https://github.com/gutenbergtools/altpoet.git`
 
-install packages from pipfile
-`pipenv install`
+2. create a python env in the new altpoet directory:
 
-to use your local postgres instance, change the settings in 
-`src/altpoet/settings/sample_local_settings.py`
-or leave them alone to use sqlite.
+   `pipenv shell`
 
-https://docs.djangoproject.com/en/5.1/topics/install/
-`django-admin migrate`
+3. install packages from pipfile
 
-now, make yourself a superuser
-`django-admin createsuperuser --username=joe --email=joe@example.com`
+   `pipenv install`
 
-load the sample data
-`django-admin load_pgimgdata data/sample_alt_data.csv `
-or get a load of PG images data from https://www.gutenberg.org/cache/epub/feeds/img_data.csv.gz
-then load it with 
-`django-admin load_images [path to unzipped data file] `
-start the server
-`django-admin rundata`
+4. to use your local postgres instance, change the settings in
+   `src/altpoet/settings/sample_local_settings.py`
+   or leave them alone to use sqlite.
 
-look at
-`http://127.0.0.1:8000/admin/`
-`http://127.0.0.1:8000/api/documents/
+5. Apply the database schema / upgrades (see also https://docs.djangoproject.com/en/5.1/topics/install/)
 
-`
+   `django-admin migrate`
+
+6. Create a superuser
+
+   `django-admin createsuperuser --username=joe --email=joe@example.com`
+
+7. load the sample data
+
+   `django-admin load_pgimgdata data/sample_alt_data.csv `
+
+   or get a load of PG images data from https://www.gutenberg.org/cache/epub/feeds/img_data.csv.gz then load it with
+
+    `django-admin load_images [path to unzipped data file] `
+
+8. start the server
+
+   `django-admin rundata`
+
+The app is now accessible on port 8000, eg:
+* http://127.0.0.1:8000/admin/
+* http://127.0.0.1:8000/api/documents/
 


### PR DESCRIPTION
The markdown in the `README.md` is unreadable when rendered, eg: https://github.com/gutenbergtools/altpoet

This just fixes that, no functional changes.